### PR TITLE
feat: make interleave with pop_addr_infos_interleave optional to match cpython

### DIFF
--- a/src/aiohappyeyeballs/utils.py
+++ b/src/aiohappyeyeballs/utils.py
@@ -34,7 +34,9 @@ def addr_to_addr_infos(
     return [(family, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", addr)]
 
 
-def pop_addr_infos_interleave(addr_infos: List[AddrInfoType], interleave: int) -> None:
+def pop_addr_infos_interleave(
+    addr_infos: List[AddrInfoType], interleave: Optional[int] = 1
+) -> None:
     """
     Pop addr_info from the list of addr_infos by family up to interleave times.
 
@@ -42,6 +44,8 @@ def pop_addr_infos_interleave(addr_infos: List[AddrInfoType], interleave: int) -
     each family should be popped of the top of the list.
     """
     seen: Dict[int, int] = {}
+    if interleave is None:
+        interleave = 1
     to_remove: List[AddrInfoType] = []
     for addr_info in addr_infos:
         family = addr_info[0]

--- a/src/aiohappyeyeballs/utils.py
+++ b/src/aiohappyeyeballs/utils.py
@@ -35,7 +35,7 @@ def addr_to_addr_infos(
 
 
 def pop_addr_infos_interleave(
-    addr_infos: List[AddrInfoType], interleave: Optional[int] = 1
+    addr_infos: List[AddrInfoType], interleave: Optional[int] = None
 ) -> None:
     """
     Pop addr_info from the list of addr_infos by family up to interleave times.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -43,6 +43,9 @@ def test_pop_addr_infos_interleave():
     addr_info_copy = addr_info.copy()
     pop_addr_infos_interleave(addr_info_copy, 2)
     assert addr_info_copy == []
+    addr_info_copy = addr_info.copy()
+    pop_addr_infos_interleave(addr_info_copy)
+    assert addr_info_copy == [ipv6_addr_info_2]
 
 
 def test_remove_addr_infos():


### PR DESCRIPTION
    cpython does not require interleave to be set for creating connections
    and will default it to 1 if happy_eyeballs_delay is set, so mirror
    that behavior in the util